### PR TITLE
Fixes clear icon not being vertically aligned in search box

### DIFF
--- a/src/features/home/AlgoliaPlaces.less
+++ b/src/features/home/AlgoliaPlaces.less
@@ -35,7 +35,7 @@
 
 #input-styling-address .algolia-places-nostyle { width: 50%; }
 #input-styling-address .ap-nostyle-icon-pin { left: 0px;top: 0px; }
-#input-styling-address .ap-nostyle-icon-clear { right: 0px;top: 2px }
+#input-styling-address .ap-nostyle-icon-clear { right: 0px;top: 0px }
 #input-styling-address input:hover { border-color: silver; }
 #input-styling-address input::placeholder { color: #aaaaaa; }
 #input-styling-address .ap-nostyle-suggestion { 


### PR DESCRIPTION
I noticed the clear icon is just slightly not vertically aligned. This pull request should resolve that.

![image](https://user-images.githubusercontent.com/3291635/37247716-78cec5ca-2474-11e8-8713-c443b38a8894.png)
